### PR TITLE
Added call to setResult to (hopefully) add the error message to the response body

### DIFF
--- a/biz.aQute.openapi.provider/src/aQute/openapi/provider/Dispatcher.java
+++ b/biz.aQute.openapi.provider/src/aQute/openapi/provider/Dispatcher.java
@@ -112,11 +112,11 @@ public class Dispatcher extends HttpServlet {
 					runtime.contexts.remove();
 				}
 			} catch (OpenAPIBase.Response e) {
-				response.setStatus(e.resultCode);
+				Object result = e.getResult();
+				context.setResult(result, e.resultCode);
 				for (Entry<String,String> entry : e.headers.entrySet()) {
 					response.addHeader(entry.getKey(), entry.getValue());
 				}
-				Object result = e.getResult();
 				context.report(e);
 				doFinalHeaders(request, response);
 			} catch (OpenAPIBase.DoNotTouchResponse e) {

--- a/biz.aQute.openapi.runtime.test/openapi/non200status.json
+++ b/biz.aQute.openapi.runtime.test/openapi/non200status.json
@@ -29,6 +29,30 @@
 					}
 				}
 			}
+		},
+		"/responsemessage": { 
+			"get": {
+				"operationId": "responsemessage",
+				"responses": {
+					"204": { 
+						"schema": { 
+							"type": "string"
+						}
+					},
+					"404" : {
+						"schema": {
+							"type" : "object",
+							"required": [  "message" ],
+							"properties": { 
+								"message": { 
+									"type": "string",
+									"description": "error message"
+								}
+							}
+						}
+					}
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Problem: 
In trying to follow [REST API error handling best practices](https://www.baeldung.com/rest-api-error-handling-best-practices) and the [OpenAPI 2.0 spec](https://swagger.io/specification/v2/), I found no way to ensure the HTTP response body had the error message/result object that the `OpenAPIBase.Response` object contains. 

## Solution: (?)
Changed the `Dispatcher` to call `context.setResult` with the `OpenAPIBase.Response` "result" object. This handles setting the resultCode, so I removed that line. 

I put a question for if this is the solution because idk how to test it